### PR TITLE
Add multi-season EPL download support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,8 @@ setup:
 	pip install -r requirements.txt
 
 data:
-	python src/download_data.py --season 2023
+        # Download last 15 Premier League seasons
+        python src/download_data.py --start 2010 --end 2024
 
 prepare:
-	python src/prepare_data.py
+        python src/prepare_data.py

--- a/README.md
+++ b/README.md
@@ -25,8 +25,9 @@ python -m venv .venv
 pip install -r requirements.txt
 
 # 3) (Option A) Manually download CSV(s) to data/raw/
-# 3) (Option B) Try the helper script (works if the URL pattern hasn't changed):
-python src/download_data.py --season 2023
+# 3) (Option B) Use the helper script to pull multiple seasons:
+python src/download_data.py                 # downloads last ~10 seasons
+# python src/download_data.py --start 2010 --end 2024  # custom range example
 
 # 4) Prepare/clean data → data/processed/matches.parquet
 python src/prepare_data.py


### PR DESCRIPTION
## Summary
- allow fetching multiple Premier League seasons via new `--start`/`--end` args with sensible defaults
- update Makefile to download last ~15 seasons
- document multi-season usage in README

## Testing
- `python -m py_compile src/download_data.py src/prepare_data.py`
- `pytest`
- `python src/download_data.py --start 2023 --end 2023` *(fails: Tunnel connection failed: 403 Forbidden)*
- `python src/prepare_data.py` *(fails: No raw CSVs found in data/raw/)*

------
https://chatgpt.com/codex/tasks/task_e_68a4443c876883219c2fd35908af08b6